### PR TITLE
Fix for analyzing internal classes where functions have default value

### DIFF
--- a/src/Distillate/Writer.php
+++ b/src/Distillate/Writer.php
@@ -159,6 +159,13 @@ class Writer
                 var_export($parameter->getDefaultValue(), true)
             );
         }
+        if ($parameter->getDeclaringClass()->isInternal()) {
+            // Last try to get some valuable data for default-value of internal classes ...
+            if ($parameter->allowsNull())
+                return ' = NULL ';
+            else
+                return ' /* internal default */ ';
+        }
         throw new \RuntimeException(
             sprintf(
             	'Optional Parameter %s has no default value',


### PR DESCRIPTION
This commit fixes the issue that you where unable to get a definition for a class that is internal.
The problem here is that you cannot get the default value for an internal class and therefore the system crashed with an exception.

Now added the following comment instead of the default value: **/\* internal default */**
This comment, furthermore, is just added if the value NULL is not allowed. If NULL, I assume that it's also the default-value. I don't know how this is handled in native extensions, but in PHP user code (what we write most likely) you can only allow NULL by defining it as default value.
-> Yes I know ... by type-casting it's allowed everywhere ..
