### PR TITLE
Allow for self executeable phar so it can be put into */bin

### DIFF
--- a/build/create-phar.php
+++ b/build/create-phar.php
@@ -8,6 +8,7 @@ if(file_exists($phar)) {
 $phar = new Phar($phar, 0 , 'interfaceDistiller.phar');
 $phar->buildFromDirectory(__DIR__ . '/../src/');
 $phar->setStub(<<<'STUB'
+#!/usr/bin/env php
 <?php
 Phar::mapPhar('interfaceDistiller.phar');
 require 'phar://interfaceDistiller.phar/autoload.php';


### PR DESCRIPTION
Doesn't break cross platform and makes life a little nicer.

See https://github.com/composer/composer/blob/master/src/Composer/Compiler.php#L170
