### PR TITLE
Fixed test suite

### DIFF
--- a/tests/unit/Distillate/WriterTest.php
+++ b/tests/unit/Distillate/WriterTest.php
@@ -138,7 +138,7 @@ class WriterTest extends \PHPUnit_Framework_TestCase
         $this->writer->writeToFile($accessors);
         $this->assertSameContentAtLine(
             'public function fgetcsv($delimiter /* = unresolvable */, ' .
-            '$enclosure /* = unresolvable */);',
+            '$enclosure /* = unresolvable */, $escape /* = unresolvable */);',
             3
         );
     }


### PR DESCRIPTION
Test suite failed while checking the output of an generated interface of `SplFileObject::fgetcsv()`. The test suite assumed that `fgetcsv()` will comsue only two parameters, but it actually comsues three parameters. Fixed expected output.
